### PR TITLE
Make service as user service (wrong branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ To build with Lazarus:
   If your OS supports systemd:
   ```
   sudo easy-switcher -i
-  sudo systemctl enable easy-switcher
-  sudo systemctl start easy-switcher
+  systemctl start --user easy-switcher
+  systemctl enable --user easy-swither
+
+  #or just
+  systemctl enable --user --now easy-swither
   ```  
   If your OS doesn't support systemd, please refer your OS documentation on how to install and run daemons. You may need to use -o or --old-style switch to run Easy Switcher as an "old-style" (true) daemon.
   

--- a/easy-switcher.lpr
+++ b/easy-switcher.lpr
@@ -49,7 +49,7 @@ type
 const
   EASY_SWITCHER_VERSION = '0.3';
 
-  SYSTEMD_UNIT_FILE = '/lib/systemd/system/easy-switcher.service';
+  SYSTEMD_UNIT_FILE = '/usr/lib/systemd/user/easy-switcher.service';
   CONFIG_FILE = '/etc/easy-switcher/default.conf';
   INPUT_DEVICES_DIR = '/dev/input/';
   UINPUT_FILE = '/dev/uinput';
@@ -170,16 +170,13 @@ var
       UnitFile := TIniFile.Create(SYSTEMD_UNIT_FILE, []);
       UnitFile.WriteString('Unit', 'Description',
         'Easy Switcher - keyboard layout switcher');
-      UnitFile.WriteString('Unit', 'Requires', 'local-fs.target');
-      UnitFile.WriteString('Unit', 'After', 'local-fs.target');
       UnitFile.WriteString('Unit', 'StartLimitIntervalSec', '10');
       UnitFile.WriteString('Unit', 'StartLimitBurst', '3');
       UnitFile.WriteString('Service', 'Type', 'simple');
       UnitFile.WriteString('Service', 'ExecStart', ParamStr(0) + ' -r');
-      UnitFile.WriteString('Service', '#User', 'easy-switcher');
       UnitFile.WriteString('Service', 'Restart', 'on-failure');
       UnitFile.WriteString('Service', 'RestartSec', '3');
-      UnitFile.WriteString('Install', 'WantedBy', 'sysinit.target ');
+      UnitFile.WriteString('Install', 'WantedBy', 'default.target ');
       Log(etInfo, Format('Easy Switcher daemon successfully installed, version: %s',
         [EASY_SWITCHER_VERSION]), False);
       if Assigned(UnitFile) then

--- a/resources/easy-switcher.service
+++ b/resources/easy-switcher.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Easy Switcher - keyboard layout switcher
+StartLimitIntervalSec=10
+StartLimitBurst=3
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/easy-switcher -r
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target 


### PR DESCRIPTION
It is not necessary to make systemd service as system-wide it should be user-localized.

Edits in main file:
1. Changed path to /usr/lib/system/user instead of /lib/system/system.
2. Changed target.
3. Removed deprecated (due changes above) lines from systemd file
and 
4. Updated README

Extra:
1. For packaging purposes systemd service file better be as separate file.

Tested and works perfectly on my system