### PR TITLE
Config: use folder .config for settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To build with Lazarus:
   
 ## Configuring
 Easy Switcher has a built-in configuration tool. For automatic configuration, run it in the terminal with the -c or --configure switch.    
-Additional tuning is available with manual configuration, please edit /etc/easy-switcher/default.conf.  
+Additional tuning is available with manual configuration, please edit $HOME/.config/easy-switcher/default.conf.
 
 ## Troubleshooting
 Run-time errors are written to syslog.  


### PR DESCRIPTION
Added the ability to create settings and run locally without root privileges.

This changed the default behavior of the program, but working with the utility became more universal and safer.